### PR TITLE
feat: Add vercel.json for Docker deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,19 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "Dockerfile",
+      "use": "@vercel/docker",
+      "config": {
+        "port": 8080,
+        "zeroConfig": true
+      }
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "/"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a `vercel.json` file to configure Vercel deployments. This file instructs Vercel to:
1. Use the existing `Dockerfile` for building the application.
2. Route all incoming requests to the service running inside the Docker container.
3. Specifies the port (8080) the application uses within the container.

This configuration is intended to resolve 404 errors when deploying the Rust application to Vercel, by ensuring Vercel correctly handles the Dockerized service.